### PR TITLE
fix 改行が CRLF だと構文解析に失敗する

### DIFF
--- a/examples/line_feed/cr.niu
+++ b/examples/line_feed/cr.niu
@@ -1,0 +1,1 @@
+fn main() -> void {  let a = 5;}

--- a/examples/line_feed/crlf.niu
+++ b/examples/line_feed/crlf.niu
@@ -1,0 +1,3 @@
+fn main() -> void {
+  let a = 5;
+}

--- a/examples/line_feed/lf.niu
+++ b/examples/line_feed/lf.niu
@@ -1,0 +1,3 @@
+fn main() -> void {
+  let a = 5;
+}

--- a/src/block.rs
+++ b/src/block.rs
@@ -56,7 +56,7 @@ impl MutCheck for Block {
 
 
 pub fn parse_block(s: &str) -> IResult<&str, Block> {
-    let (s, (vec, _, return_exp, _)) = tuple((many0(tuple((space0, parse_statement, space0, tag(";")))), space0, opt(parse_expression), space0))(s)?;
+    let (s, (vec, _, return_exp, _)) = tuple((many0(tuple((multispace0, parse_statement, multispace0, tag(";")))), multispace0, opt(parse_expression), multispace0))(s)?;
     let mut statements = Vec::new();
     for (_, st, _, _) in vec {
         statements.push(st);

--- a/src/cpp_inline.rs
+++ b/src/cpp_inline.rs
@@ -73,12 +73,12 @@ impl CppInline {
 }
 
 fn parse_inline_elem_type(s: &str) -> IResult<&str, CppInlineElem> {
-    let (s, (_, _, id, _, _)) = tuple((tag("$ty("), space0, parse_type_id, space0, tag(")")))(s)?;
+    let (s, (_, _, id, _, _)) = tuple((tag("$ty("), multispace0, parse_type_id, multispace0, tag(")")))(s)?;
     Ok((s, CppInlineElem::Type(id)))
 }
 
 fn parse_inline_elem_arg(s: &str) -> IResult<&str, CppInlineElem> {
-    let (s, (_, _, id, _, _)) = tuple((tag("$arg("), space0, parse_identifier, space0, tag(")")))(s)?;
+    let (s, (_, _, id, _, _)) = tuple((tag("$arg("), multispace0, parse_identifier, multispace0, tag(")")))(s)?;
     Ok((s, CppInlineElem::Arg(id)))
 }
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -61,7 +61,7 @@ where
     P::Operator: ParseOperator,
 {
     let (s, (head, _, tails)) = 
-        tuple((P::Child::parse_expression, space0, many0(tuple((P::Operator::parse_operator, space0, P::Child::parse_expression, space0)))))(s)?;
+        tuple((P::Child::parse_expression, multispace0, many0(tuple((P::Operator::parse_operator, multispace0, P::Child::parse_expression, multispace0)))))(s)?;
     let mut terms = vec![head];
     let mut opes = Vec::new();
 
@@ -746,7 +746,7 @@ impl ParseExpression for ExpMulDivRem {
     }
     fn parse_expression(s: &str) -> IResult<&str, Self> {
         let (s, (head, _, tails)) = 
-            tuple((parse_exp_unary_ope, space0, many0(tuple((Self::Operator::parse_operator, space0, parse_exp_unary_ope, space0)))))(s)?;
+            tuple((parse_exp_unary_ope, multispace0, many0(tuple((Self::Operator::parse_operator, multispace0, parse_exp_unary_ope, multispace0)))))(s)?;
         let mut unary_exprs = vec![head];
         let mut opes = Vec::new();
 
@@ -847,16 +847,16 @@ impl MutCheck for ExpUnaryOpe {
 }
 
 pub fn parse_exp_unary_ope_ref(s: &str) -> IResult<&str, ExpUnaryOpe> {
-    let (s, (_, _, exp)) = tuple((char('&'), space0, parse_exp_unary_ope))(s)?;
+    let (s, (_, _, exp)) = tuple((char('&'), multispace0, parse_exp_unary_ope))(s)?;
     Ok((s, ExpUnaryOpe::Ref(Box::new(exp))))
 }
 pub fn parse_exp_unary_ope_mutref(s: &str) -> IResult<&str, ExpUnaryOpe> {
-    let (s, (_, _, exp)) = tuple((tag("&mut"), space0, parse_exp_unary_ope))(s)?;
+    let (s, (_, _, exp)) = tuple((tag("&mut"), multispace0, parse_exp_unary_ope))(s)?;
     Ok((s, ExpUnaryOpe::MutRef(Box::new(exp))))
 }
 
 pub fn parse_exp_unary_ope_deref(s: &str) -> IResult<&str, ExpUnaryOpe> {
-    let (s, (_, _, exp)) = tuple((char('*'), space0, parse_exp_unary_ope))(s)?;
+    let (s, (_, _, exp)) = tuple((char('*'), multispace0, parse_exp_unary_ope))(s)?;
     Ok((s, ExpUnaryOpe::Deref(Box::new(exp), Tag::new())))
 }
 

--- a/src/expression/for_expr.rs
+++ b/src/expression/for_expr.rs
@@ -57,11 +57,11 @@ impl MutCheck for ForExpr {
 
 pub fn parse_for_expr(s: &str) -> IResult<&str, Expression> {
     let (s, (_, _, _, _, init, _, _, _, cond, _, _, _, update, _, _, _, _, _, block, _, _)) =
-        tuple((tag("for"), space0, char('('), space0,
-            parse_statement, space0, char(';'), space0,
-            parse_expression, space0, char(';'), space0,
-            alt((parse_substitute_to_statement, parse_expression_to_statement)), space0, char(')'), space0, char('{'), space0,
-            parse_block, space0, char('}')))(s)?;
+        tuple((tag("for"), multispace0, char('('), multispace0,
+            parse_statement, multispace0, char(';'), multispace0,
+            parse_expression, multispace0, char(';'), multispace0,
+            alt((parse_substitute_to_statement, parse_expression_to_statement)), multispace0, char(')'), multispace0, char('{'), multispace0,
+            parse_block, multispace0, char('}')))(s)?;
     Ok((s, Expression::ForExpr(Box::new(ForExpr { init, cond, update, block }))))
 }
 

--- a/src/expression/if_expr.rs
+++ b/src/expression/if_expr.rs
@@ -82,9 +82,9 @@ impl MutCheck for IfExpr {
 }
 
 pub fn parse_if_expr(s: &str) -> IResult<&str, Expression> {
-    let (s, (_, _, if_cond, _, _, if_block, _, _, many, _, _, _, el_block, _, _)) = tuple((tag("if"), space1, parse_expression, space0, char('{'), parse_block, char('}'), space0,
-                        many0(tuple((tag("else"), space1, tag("if"), space1, parse_expression, space0, char('{'), parse_block, char('}'), space0))),
-                        tag("else"), space1, char('{'), parse_block, char('}'), space0))(s)?;
+    let (s, (_, _, if_cond, _, _, if_block, _, _, many, _, _, _, el_block, _, _)) = tuple((tag("if"), space1, parse_expression, multispace0, char('{'), parse_block, char('}'), multispace0,
+                        many0(tuple((tag("else"), space1, tag("if"), space1, parse_expression, multispace0, char('{'), parse_block, char('}'), multispace0))),
+                        tag("else"), space1, char('{'), parse_block, char('}'), multispace0))(s)?;
     let ifp = IfPair { cond: if_cond, block: if_block };
     let elifp = many.into_iter().map(|(_, _, _, _, cond, _, _, block, _, _)| IfPair { cond, block }).collect::<Vec<_>>();
     Ok((s, Expression::IfExpr(Box::new(IfExpr { ifp, elifp, el_block, tag: Tag::new(), }))))

--- a/src/full_content.rs
+++ b/src/full_content.rs
@@ -167,7 +167,7 @@ fn parse_element_impl_trait(s: &str) -> IResult<&str, ContentElement> {
 }
 
 fn parse_element_import(s: &str) -> IResult<&str, ContentElement> {
-    let (s, (_, _, _, _, path, _, _)) = tuple((space0, tag("import"), space0, char('"'), is_not("\""), char('"'), space0))(s)?;
+    let (s, (_, _, _, _, path, _, _)) = tuple((multispace0, tag("import"), multispace0, char('"'), is_not("\""), char('"'), multispace0))(s)?;
     Ok((s, ContentElement::Import(path.to_string())))
 }
 
@@ -177,7 +177,7 @@ fn parse_content_element(s: &str) -> IResult<&str, ContentElement> {
 }
 
 pub fn parse_full_content(s: &str) -> IResult<&str, (Vec<String>, FullContent)> {
-    let (s, (_, elems, _)) = tuple((space0, many0(tuple((parse_content_element, space0))), space0))(s)?;
+    let (s, (_, elems, _)) = tuple((multispace0, many0(tuple((parse_content_element, multispace0))), multispace0))(s)?;
     
     let mut structs = Vec::new();
     let mut funcs = Vec::new();
@@ -217,7 +217,6 @@ pub fn parse_full_content_from_file(filename: &str, import_path: &[PathBuf]) -> 
     
     while let Some(path) = que.pop() {
         let program = std::fs::read_to_string(path.as_path()).map_err(|_| format!("cant open {}", filename))?;
-        let program = program.chars().map(|c| match c { '\n' => ' ', c => c }).collect::<String>();
         let (s, (imports, mut full)) = crate::full_content::parse_full_content(&program).map_err(|e| format!("{:?}", e))?;
         if s != "" {
             Err(format!("path {:?} parse error, remaining -> {}", path, s))?;

--- a/src/func_definition.rs
+++ b/src/func_definition.rs
@@ -231,16 +231,16 @@ impl Transpile for FuncDefinition {
 }
 
 /*fn parse_generics_arg(s: &str) -> IResult<&str, (TypeId, Option<TraitId>)> {
-    let (s, (id, _, opt)) = tuple((parse_type_id, space0, opt(tuple((char(':'), space0, parse_trait_id)))))(s)?;
+    let (s, (id, _, opt)) = tuple((parse_type_id, multispace0, opt(tuple((char(':'), multispace0, parse_trait_id)))))(s)?;
     Ok((s, (id, opt.map(|(_, _, tr)| tr))))
 }*/
 
 pub fn parse_func_definition_info(s: &str) -> IResult<&str, FuncDefinitionInfo> {
     let (s, (_, _, func_id, _, generics_opt, _, _, _, op, _, _, _, _, return_type, _, where_sec)) = 
-        tuple((tag("fn"), space1, parse_identifier, space0, opt(tuple((char('<'), space0, opt(tuple((parse_type_id, space0, many0(tuple((char(','), space0, parse_type_id, space0))), opt(char(',')), space0))), char('>'), space0))), space0,
-               char('('), space0,
-            opt(tuple((parse_identifier, space0, char(':'), space0, parse_type_spec, space0, many0(tuple((char(','), space0, parse_identifier, space0, char(':'), space0, parse_type_spec, space0))), opt(char(',')), space0))),
-            char(')'), space0, tag("->"), space0, parse_type_spec, space0, parse_where_section))(s)?;
+        tuple((tag("fn"), space1, parse_identifier, multispace0, opt(tuple((char('<'), multispace0, opt(tuple((parse_type_id, multispace0, many0(tuple((char(','), multispace0, parse_type_id, multispace0))), opt(char(',')), multispace0))), char('>'), multispace0))), multispace0,
+               char('('), multispace0,
+            opt(tuple((parse_identifier, multispace0, char(':'), multispace0, parse_type_spec, multispace0, many0(tuple((char(','), multispace0, parse_identifier, multispace0, char(':'), multispace0, parse_type_spec, multispace0))), opt(char(',')), multispace0))),
+            char(')'), multispace0, tag("->"), multispace0, parse_type_spec, multispace0, parse_where_section))(s)?;
     let generics = match generics_opt {
         Some((_, _, generics_opt, _, _)) => {
             match generics_opt {
@@ -285,7 +285,7 @@ fn parse_func_block(s: &str) -> IResult<&str, FuncBlock> {
 }
 
 pub fn parse_func_definition(s: &str) -> IResult<&str, FuncDefinition> {
-    let (s, (info, _, block)) = tuple((parse_func_definition_info, space0, parse_func_block))(s)?;
+    let (s, (info, _, block)) = tuple((parse_func_definition_info, multispace0, parse_func_block))(s)?;
     Ok((s, FuncDefinition { func_id: info.func_id, generics: info.generics, where_sec: info.where_sec, args: info.args, return_type: info.return_type, block }))
 }
 

--- a/src/let_declaration.rs
+++ b/src/let_declaration.rs
@@ -55,7 +55,7 @@ impl MutCheck for LetDeclaration {
 
 
 pub fn parse_let_declaration(s: &str) -> IResult<&str, LetDeclaration> {
-    let (s, (_let, _, is_mut, id, _, tyinfo, _, _e, _, value)) = tuple((tag("let"), space1, opt(tuple((tag("mut"), space1))), parse_identifier, space0, opt(tuple((char(':'), space0, parse_type_spec))), space0, tag("="), space0, parse_expression))(s)?;
+    let (s, (_let, _, is_mut, id, _, tyinfo, _, _e, _, value)) = tuple((tag("let"), space1, opt(tuple((tag("mut"), space1))), parse_identifier, multispace0, opt(tuple((char(':'), multispace0, parse_type_spec))), multispace0, tag("="), multispace0, parse_expression))(s)?;
     Ok((s, (LetDeclaration { id, is_mut: is_mut.is_some(), type_info: tyinfo.map(|(_, _, type_info)| type_info ), value })))
 }
 

--- a/src/structs/impl_self.rs
+++ b/src/structs/impl_self.rs
@@ -160,7 +160,7 @@ impl ImplSelfCandidate {
 }
 
 fn parse_generics_args(s: &str) -> IResult<&str, Vec<TypeId>> {
-    let (s, op) = opt(tuple((space0, char('<'), space0, separated_list0(tuple((space0, char(','), space0)), parse_type_id), space0, char('>'))))(s)?;
+    let (s, op) = opt(tuple((multispace0, char('<'), multispace0, separated_list0(tuple((multispace0, char(','), multispace0)), parse_type_id), multispace0, char('>'))))(s)?;
     Ok((s, op.map(|(_, _, _, res, _, _)| res).unwrap_or(Vec::new())))
 }
 
@@ -168,10 +168,10 @@ pub fn parse_impl_self_definition(s: &str) -> IResult<&str, ImplSelfDefinition> 
     let (s, (_, generics, _, impl_ty, _, where_sec, _, _, _, many_methods, _, _)) = 
         tuple((tag("impl"), parse_generics_args,
             space1, parse_type_spec,
-            space0, parse_where_section,
-            space0, char('{'), space0,
-            many0(tuple((parse_func_definition, space0))),
-            space0, char('}')))(s)?;
+            multispace0, parse_where_section,
+            multispace0, char('{'), multispace0,
+            many0(tuple((parse_func_definition, multispace0))),
+            multispace0, char('}')))(s)?;
     let require_methods = many_methods.into_iter().map(|(func, _)| (func.func_id.clone(), func)).collect();
     Ok((s, ImplSelfDefinition { generics, impl_ty, where_sec, require_methods, tag: Tag::new() }))
 }

--- a/src/structs/struct_definition.rs
+++ b/src/structs/struct_definition.rs
@@ -130,12 +130,12 @@ impl StructMemberDefinition {
 }
 
 fn parse_member(s: &str) -> IResult<&str, (Identifier, TypeSpec)> {
-    let (s, (id, _, _, _, ty)) = tuple((parse_identifier, space0, char(':'), space0, parse_type_spec))(s)?;
+    let (s, (id, _, _, _, ty)) = tuple((parse_identifier, multispace0, char(':'), multispace0, parse_type_spec))(s)?;
     Ok((s, (id, ty)))
 }
 
 fn parse_generics_annotation(s: &str) -> IResult<&str, Vec<TypeId>> {
-    let (s, op) = opt(tuple((char('<'), space0, parse_type_id, space0, many0(tuple((char(','), space0, parse_type_id, space0))), opt(tuple((space0, char(',')))), space0, char('>'))))(s)?;
+    let (s, op) = opt(tuple((char('<'), multispace0, parse_type_id, multispace0, many0(tuple((char(','), multispace0, parse_type_id, multispace0))), opt(tuple((multispace0, char(',')))), multispace0, char('>'))))(s)?;
     let v = match op {
         None => Vec::new(),
         Some((_, _, ty, _, m0, _, _, _)) => {
@@ -150,8 +150,8 @@ fn parse_generics_annotation(s: &str) -> IResult<&str, Vec<TypeId>> {
 }
 
 fn parse_struct_members(s: &str) -> IResult<&str, StructMember> {
-    let (s, (_, _, opts, _)) = tuple((char('{'), space0,
-                         opt(tuple((parse_member, many0(tuple((space0, char(','), space0, parse_member))), opt(tuple((space0, char(',')))), space0))),
+    let (s, (_, _, opts, _)) = tuple((char('{'), multispace0,
+                         opt(tuple((parse_member, many0(tuple((multispace0, char(','), multispace0, parse_member))), opt(tuple((multispace0, char(',')))), multispace0))),
                          char('}')))(s)?;
     let (members_order, members) = match opts {
         None => (Vec::new(), HashMap::new()),
@@ -174,13 +174,13 @@ fn parse_struct_cpp_inline(s: &str) -> IResult<&str, StructMember> {
 
 pub fn parse_struct_member_definition(s: &str) -> IResult<&str, StructMemberDefinition> {
     let (s, (_, _, struct_id, _, generics, _, member)) =
-        tuple((tag("struct"), space1, parse_type_id, space0, parse_generics_annotation, space0, alt((parse_struct_members, parse_struct_cpp_inline))))(s)?;
+        tuple((tag("struct"), space1, parse_type_id, multispace0, parse_generics_annotation, multispace0, alt((parse_struct_members, parse_struct_cpp_inline))))(s)?;
     Ok((s, StructMemberDefinition { struct_id, generics, member }))
 }
 
 pub fn parse_struct_definition(s: &str) -> IResult<&str, StructDefinition> {
-    let (s, (member_def, _, _, _, funcs, _)) = tuple((parse_struct_member_definition, space0, char('{'), space0,
-            many0(tuple((parse_func_definition, space0))), char('}')))(s)?;
+    let (s, (member_def, _, _, _, funcs, _)) = tuple((parse_struct_member_definition, multispace0, char('{'), multispace0,
+            many0(tuple((parse_func_definition, multispace0))), char('}')))(s)?;
     let require_methods = funcs.into_iter().map(|(func, _)| (func.func_id.clone(), func)).collect();
     let impl_self = ImplSelfDefinition {
         generics: member_def.generics.clone(),

--- a/src/structs/struct_instantiation.rs
+++ b/src/structs/struct_instantiation.rs
@@ -38,13 +38,13 @@ impl GenType for StructInstantiation {
 }
 
 fn parse_member(s: &str) -> IResult<&str, (Identifier, Expression)> {
-    let (s, (id, _, _, _, ty)) = tuple((parse_identifier, space0, char(':'), space0, parse_expression))(s)?;
+    let (s, (id, _, _, _, ty)) = tuple((parse_identifier, multispace0, char(':'), multispace0, parse_expression))(s)?;
     Ok((s, (id, ty)))
 }
 
 pub fn parse_struct_instantiation(s: &str) -> IResult<&str, UnaryExpr> {
-    let (s, (struct_id, _, _, _, opts, _)) = tuple((parse_type_id, space0, char('{'), space0,
-                         opt(tuple((parse_member, many0(tuple((space0, char(','), space0, parse_member))), opt(tuple((space0, char(',')))), space0))),
+    let (s, (struct_id, _, _, _, opts, _)) = tuple((parse_type_id, multispace0, char('{'), multispace0,
+                         opt(tuple((parse_member, many0(tuple((multispace0, char(','), multispace0, parse_member))), opt(tuple((multispace0, char(',')))), multispace0))),
                          char('}')))(s)?;
     let members = match opts {
         None => HashMap::new(),

--- a/src/subseq.rs
+++ b/src/subseq.rs
@@ -253,7 +253,7 @@ pub fn subseq_mut_check(uexpr: &UnaryExpr, subseq: &Subseq, ta: &TypeAnnotation,
 
 
 pub fn parse_subseq(s: &str) -> IResult<&str, Subseq> {
-    let (s, (_, x)) = tuple((space0, alt((parse_call, parse_member, parse_index_call))))(s)?;
+    let (s, (_, x)) = tuple((multispace0, alt((parse_call, parse_member, parse_index_call))))(s)?;
     Ok((s, x))
 }
 
@@ -265,9 +265,9 @@ pub struct Call {
 
 pub fn parse_call(s: &str) -> IResult<&str, Subseq> {
     let (s, (_, _, op, _)) = tuple((
-        char('('), space0, opt(tuple((
-                    parse_expression, space0,
-                    many0(tuple((char(','), space0, parse_expression, space0))), opt(char(',')), space0))),
+        char('('), multispace0, opt(tuple((
+                    parse_expression, multispace0,
+                    many0(tuple((char(','), multispace0, parse_expression, multispace0))), opt(char(',')), multispace0))),
                     char(')')))(s)?;
     let args = match op {
         Some((arg0, _, many, _, _)) => {
@@ -290,7 +290,7 @@ pub struct IndexCall {
 
 pub fn parse_index_call(s: &str) -> IResult<&str, Subseq> {
     let (s, (_, _, arg, _, _)) = tuple((
-            char('['), space0, parse_expression, space0, char(']')
+            char('['), multispace0, parse_expression, multispace0, char(']')
             ))(s)?;
     Ok((s, Subseq::Index(IndexCall { arg: Box::new(arg), tag: Tag::new() })))
 }
@@ -301,7 +301,7 @@ pub struct Member {
 }
 
 fn parse_member(s: &str) -> IResult<&str, Subseq> {
-    let (s, (_, _, mem_id)) = tuple((char('.'), space0, parse_identifier))(s)?;
+    let (s, (_, _, mem_id)) = tuple((char('.'), multispace0, parse_identifier))(s)?;
     Ok((s, Subseq::Member(Member { mem_id })))
 }
 

--- a/src/substitute.rs
+++ b/src/substitute.rs
@@ -47,6 +47,6 @@ impl MutCheck for Substitute {
 }
 
 pub fn parse_substitute(s: &str) -> IResult<&str, Substitute> {
-    let (s, (into_expr, _, _e, _, value)) = tuple((parse_expression, space0, tag("="), space0, parse_expression))(s)?;
+    let (s, (into_expr, _, _e, _, value)) = tuple((parse_expression, multispace0, tag("="), multispace0, parse_expression))(s)?;
     Ok((s, Substitute { into_expr, value, }))
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -75,10 +75,10 @@ impl Transpile for TraitDefinition {
 pub fn parse_trait_definition(s: &str) -> IResult<&str, TraitDefinition> {
     let (s, (_, _, trait_id, _, where_sec, _, _, _, many_types, many_methods, _, _)) = 
         tuple((tag("trait"), space1, parse_trait_id,
-            space0, parse_where_section, space0, char('{'), space0,
-            many0(tuple((tag("type"), space1, parse_associated_type_identifier, space0, char(';'), space0))),
-            many0(tuple((parse_func_definition_info, space0, char(';'), space0))),
-            space0, char('}')))(s)?;
+            multispace0, parse_where_section, multispace0, char('{'), multispace0,
+            many0(tuple((tag("type"), space1, parse_associated_type_identifier, multispace0, char(';'), multispace0))),
+            many0(tuple((parse_func_definition_info, multispace0, char(';'), multispace0))),
+            multispace0, char('}')))(s)?;
     let asso_ids = many_types.into_iter().map(|(_, _, id, _, _, _)| id).collect();
     let required_methods = many_methods.into_iter().map(|(info, _, _, _)| (TraitMethodIdentifier { id: info.func_id.clone() }, info)).collect();
     Ok((s, TraitDefinition { trait_id, where_sec, asso_ids, required_methods }))

--- a/src/traits/associated_type.rs
+++ b/src/traits/associated_type.rs
@@ -31,7 +31,7 @@ pub struct AssociatedType {
 }
 
 pub fn parse_associated_type(s: &str) -> IResult<&str, AssociatedType> {
-    let (s, (trait_id, _, _, _, type_id)) = tuple((parse_trait_id, space0, tag("::"), space0, parse_associated_type_identifier))(s)?;
+    let (s, (trait_id, _, _, _, type_id)) = tuple((parse_trait_id, multispace0, tag("::"), multispace0, parse_associated_type_identifier))(s)?;
     Ok((s, AssociatedType { trait_id, type_id }))
 }
 

--- a/src/traits/candidate.rs
+++ b/src/traits/candidate.rs
@@ -148,7 +148,7 @@ impl ImplDefinition {
 }
 
 fn parse_generics_args(s: &str) -> IResult<&str, Vec<TypeId>> {
-    let (s, op) = opt(tuple((space0, char('<'), space0, separated_list0(tuple((space0, char(','), space0)), parse_type_id), space0, char('>'))))(s)?;
+    let (s, op) = opt(tuple((multispace0, char('<'), multispace0, separated_list0(tuple((multispace0, char(','), multispace0)), parse_type_id), multispace0, char('>'))))(s)?;
     Ok((s, op.map(|(_, _, _, res, _, _)| res).unwrap_or(Vec::new())))
 }
 
@@ -157,11 +157,11 @@ pub fn parse_impl_definition(s: &str) -> IResult<&str, ImplDefinition> {
         tuple((tag("impl"), parse_generics_args,
             space1, parse_trait_id,
             space1, tag("for"), space1, parse_type_spec,
-            space0, parse_where_section,
-            space0, char('{'), space0,
-            many0(tuple((tag("type"), space1, parse_associated_type_identifier, space0, char('='), space0, parse_type_spec, space0, char(';'), space0))),
-            many0(tuple((parse_func_definition, space0))),
-            space0, char('}')))(s)?;
+            multispace0, parse_where_section,
+            multispace0, char('{'), multispace0,
+            many0(tuple((tag("type"), space1, parse_associated_type_identifier, multispace0, char('='), multispace0, parse_type_spec, multispace0, char(';'), multispace0))),
+            many0(tuple((parse_func_definition, multispace0))),
+            multispace0, char('}')))(s)?;
     let asso_defs = many_types.into_iter().map(|(_, _, id, _, _, _, ty, _, _, _)| (id, ty)).collect();
     let require_methods = many_methods.into_iter().map(|(func, _)| (TraitMethodIdentifier { id: func.func_id.clone() }, func)).collect();
     Ok((s, ImplDefinition { generics, trait_id, impl_ty, where_sec, asso_defs, require_methods }))

--- a/src/traits/trait_method.rs
+++ b/src/traits/trait_method.rs
@@ -31,6 +31,6 @@ pub struct TraitMethod {
 }
 
 pub fn parse_trait_method(s: &str) -> IResult<&str, TraitMethod> {
-    let (s, (trait_id, _, _, _, method_id)) = tuple((parse_trait_id, space0, tag("."), space0, parse_trait_method_identifier))(s)?;
+    let (s, (trait_id, _, _, _, method_id)) = tuple((parse_trait_id, multispace0, tag("."), multispace0, parse_trait_method_identifier))(s)?;
     Ok((s, TraitMethod { trait_id, method_id }))
 }

--- a/src/type_spec.rs
+++ b/src/type_spec.rs
@@ -98,7 +98,7 @@ impl TypeSign {
 }
 
 fn parse_generics_annotation(s: &str) -> IResult<&str, Vec<TypeSpec>> {
-    let (s, op) = opt(tuple((char('<'), space0, parse_type_spec, space0, many0(tuple((char(','), space0, parse_type_spec, space0))), opt(tuple((space0, char(',')))), space0, char('>'))))(s)?;
+    let (s, op) = opt(tuple((char('<'), multispace0, parse_type_spec, multispace0, many0(tuple((char(','), multispace0, parse_type_spec, multispace0))), opt(tuple((multispace0, char(',')))), multispace0, char('>'))))(s)?;
     let v = match op {
         None => Vec::new(),
         Some((_, _, ty, _, m0, _, _, _)) => {
@@ -114,7 +114,7 @@ fn parse_generics_annotation(s: &str) -> IResult<&str, Vec<TypeSpec>> {
 
 
 pub fn parse_type_sign(s: &str) -> IResult<&str, TypeSign> {
-    let (s, (id, _, gens)) = tuple((parse_type_id, space0, parse_generics_annotation))(s)?;
+    let (s, (id, _, gens)) = tuple((parse_type_id, multispace0, parse_generics_annotation))(s)?;
     Ok((s, TypeSign { id, gens }))
 }
 
@@ -236,7 +236,7 @@ impl TypeSpec {
 }
 
 fn parse_type_spec_subseq(s: &str, prev: TypeSpec) -> IResult<&str, TypeSpec> {
-    if let Ok((ss, (_, _, _, asso_ty))) = tuple((space0, char('#'), space0, parse_associated_type))(s) {
+    if let Ok((ss, (_, _, _, asso_ty))) = tuple((multispace0, char('#'), multispace0, parse_associated_type))(s) {
         parse_type_spec_subseq(ss, TypeSpec::Associated(Box::new(prev), asso_ty))
     }
     else {
@@ -245,17 +245,17 @@ fn parse_type_spec_subseq(s: &str, prev: TypeSpec) -> IResult<&str, TypeSpec> {
 }
 
 fn parse_type_spec_pointer(s: &str) -> IResult<&str, TypeSpec> {
-    let (s, (_, _, spec)) = tuple((tag("&"), space0, parse_type_spec))(s)?;
+    let (s, (_, _, spec)) = tuple((tag("&"), multispace0, parse_type_spec))(s)?;
     Ok((s, TypeSpec::Pointer(Box::new(spec))))
 }
 
 fn parse_type_spec_mutpointer(s: &str) -> IResult<&str, TypeSpec> {
-    let (s, (_, _, spec)) = tuple((tag("&mut"), space0, parse_type_spec))(s)?;
+    let (s, (_, _, spec)) = tuple((tag("&mut"), multispace0, parse_type_spec))(s)?;
     Ok((s, TypeSpec::MutPointer(Box::new(spec))))
 }
 
 fn parse_type_spec_paren(s: &str) -> IResult<&str, TypeSpec> {
-    let (s, (_, _, spec, _)) = tuple((tag("("), space0, parse_type_spec, tag(")")))(s)?;
+    let (s, (_, _, spec, _)) = tuple((tag("("), multispace0, parse_type_spec, tag(")")))(s)?;
     Ok((s, spec))
 }
 

--- a/src/unary_expr.rs
+++ b/src/unary_expr.rs
@@ -162,18 +162,18 @@ impl MutCheck for Parentheses {
 }
 
 pub fn parse_parentheses(s: &str) -> IResult<&str, UnaryExpr> {
-    let(s, (_, _, expr, _, _)) = tuple((char('('), space0, parse_expression, space0, char(')')))(s)?;
+    let(s, (_, _, expr, _, _)) = tuple((char('('), multispace0, parse_expression, multispace0, char(')')))(s)?;
     Ok((s, UnaryExpr::Parentheses(Parentheses { expr })))
 }
 
 pub fn parse_bracket_block(s: &str) -> IResult<&str, UnaryExpr> {
-    let(s, (_, _, block, _, _)) = tuple((char('{'), space0, parse_block, space0, char('}')))(s)?;
+    let(s, (_, _, block, _, _)) = tuple((char('{'), multispace0, parse_block, multispace0, char('}')))(s)?;
     Ok((s, UnaryExpr::Block(block)))
 }
 
 pub fn parse_unary_trait_method(ss: &str) -> IResult<&str, UnaryExpr> {
-    let (s, (typesign, _)) = tuple((parse_type_sign, space0))(ss)?;
-    let (s, elems) = many1(tuple((opt(tuple((char('#'), space0, parse_trait_id))), space0, tag("::"), space0, parse_identifier, space0)))(s)?;
+    let (s, (typesign, _)) = tuple((parse_type_sign, multispace0))(ss)?;
+    let (s, elems) = many1(tuple((opt(tuple((char('#'), multispace0, parse_trait_id))), multispace0, tag("::"), multispace0, parse_identifier, multispace0)))(s)?;
     let mut elems = elems.into_iter().map(|(op, _, _, _, id, _)| (op.map(|(_, _, tr_id)| tr_id), id)).collect::<Vec<_>>();
     let (tail_tr_op, tail_id) = elems.pop().unwrap();
     let mut ty = TypeSpec::TypeSign(typesign);

--- a/src/unify/where_section.rs
+++ b/src/unify/where_section.rs
@@ -89,12 +89,12 @@ impl WhereSection {
 }
 
 fn parse_associated_type_specifier_elem(s: &str) -> IResult<&str, (AssociatedTypeIdentifier, TypeSpec)> {
-    let (s, (id, _, _, _, spec)) = tuple((parse_associated_type_identifier, space0, char('='), space0, parse_type_spec))(s)?;
+    let (s, (id, _, _, _, spec)) = tuple((parse_associated_type_identifier, multispace0, char('='), multispace0, parse_type_spec))(s)?;
     Ok((s, (id, spec)))
 }
 
 fn parse_associated_type_specifiers(s: &str) -> IResult<&str, Vec<(AssociatedTypeIdentifier, TypeSpec)>> {
-    let (s, op) = opt(tuple((char('('), space0, separated_list0(tuple((space0, char(','), space0)), parse_associated_type_specifier_elem), space0, char(')'))))(s)?;
+    let (s, op) = opt(tuple((char('('), multispace0, separated_list0(tuple((multispace0, char(','), multispace0)), parse_associated_type_specifier_elem), multispace0, char(')'))))(s)?;
     let res = match op {
         Some((_, _, res, _, _)) => res,
         None => Vec::new(),
@@ -103,7 +103,7 @@ fn parse_associated_type_specifiers(s: &str) -> IResult<&str, Vec<(AssociatedTyp
 }
 
 fn parse_has_trait_element(s: &str) -> IResult<&str, (TypeSpec, usize, TraitId, Vec<(AssociatedTypeIdentifier, TypeSpec)>)> {
-    let (s, (spec, _, _, _, tr_id, _, assos)) = tuple((parse_type_spec, space0, char(':'), space0, parse_trait_id, space0, parse_associated_type_specifiers))(s)?;
+    let (s, (spec, _, _, _, tr_id, _, assos)) = tuple((parse_type_spec, multispace0, char(':'), multispace0, parse_trait_id, multispace0, parse_associated_type_specifiers))(s)?;
     let dep = spec.associated_type_depth();
     Ok((s, (spec, dep, tr_id, assos)))
 }
@@ -112,8 +112,8 @@ pub fn parse_where_section(s: &str) -> IResult<&str, WhereSection> {
     let (s, op) = opt(
         tuple((
                 tag("where"), space1,
-                separated_list0(tuple((space0, char(','), space0)), parse_has_trait_element),
-                opt(tuple((space0, char(','))))
+                separated_list0(tuple((multispace0, char(','), multispace0)), parse_has_trait_element),
+                opt(tuple((multispace0, char(','))))
                 ))
         )(s)?;
     let has_traits = match op {


### PR DESCRIPTION
#11 

`examples/line_feed/lf.niu` `examples/line_feed/crlf.niu` `examples/line_feed/cr.niu`でパースできていることを確認しました.