### PR TITLE
Fix void main でなくて int main を使ってください

### DIFF
--- a/examples/main.niu
+++ b/examples/main.niu
@@ -1,0 +1,9 @@
+fn scan_a() -> u64 $${int a; std::cin >> a;}$$
+fn scan_b() -> u64 $${int b; std::cin >> b;}$$
+fn print_aplusb() -> void $${std::cout << a + b << std::endl;}$$
+
+fn main() -> void {
+  scan_a();
+  scan_b();
+  print_aplusb();
+}

--- a/src/func_definition.rs
+++ b/src/func_definition.rs
@@ -126,6 +126,24 @@ impl FuncDefinition {
     }
     pub fn unify_definition(&self, equs: &mut TypeEquations, trs: &TraitsInfo) -> Result<(), String> {
         if let FuncBlock::Block(ref block) = self.block {
+            if self.func_id == Identifier::from_str("main") {
+                if self.generics.len() > 0 {
+                    Err(format!("main function must not have generics arguments"))
+                }
+                else if !self.where_sec.is_empty() {
+                    Err(format!("main function must not have where sections"))
+                }
+                else if self.return_type != TypeSpec::from_str("void") {
+                    Err(format!("main function must return void"))
+                }
+                else {
+                    Ok(())
+                }
+            }
+            else {
+                Ok(())
+            }?;
+
             equs.into_scope();
 
             let mut trs = trs.into_scope();
@@ -192,7 +210,13 @@ impl FuncDefinition {
                 "".to_string()
             };
 
-        let return_str = self.return_type.transpile(ta);
+        let return_str = if self.func_id == Identifier::from_str("main") {
+            format!("int")
+        }
+        else {
+            self.return_type.transpile(ta)
+        };
+        
         let func_str = self.func_id.into_string();
         let arg_str = self.args.iter().map(|(id, ty)| {
             format!("{} {}", ty.transpile(ta), id.into_string())

--- a/src/unify/where_section.rs
+++ b/src/unify/where_section.rs
@@ -22,6 +22,9 @@ impl WhereSection {
     pub fn empty() -> Self {
         WhereSection { has_traits: Vec::new() }
     }
+    pub fn is_empty(&self) -> bool {
+        self.has_traits.is_empty()
+    }
     pub fn regist_equations(&self, mp: &GenericsTypeMap, equs: &mut TypeEquations, trs: &TraitsInfo) -> Result<(), String> {
         for (spec, _, tr_id, asso_eqs) in self.has_traits.iter() {
             let ty = spec.generics_to_type(mp, equs, trs)?;


### PR DESCRIPTION
#13

Niuの`void main()`をC++の`int main()`に対応させ, ジェネリクスや`where`をさせないようにしました.