### PR TITLE
Generics付きTraitの実装

### DIFF
--- a/examples/generics_trait.niu
+++ b/examples/generics_trait.niu
@@ -11,7 +11,8 @@ impl Add<u64> for u64 {
 }
 
 fn try_add<S, T>(s: S, t: T) -> S#Add<T>::Output where S: Add<T> {
-  s.add(t)
+  let ans = s.add(t);
+  ans
 }
 
 fn main() -> void {

--- a/examples/generics_trait.niu
+++ b/examples/generics_trait.niu
@@ -1,0 +1,20 @@
+trait Add<Arg> {
+  type Output;
+  fn add(self: Self, arg: Arg) -> Self#Add<Arg>::Output;
+}
+
+impl Add<u64> for u64 {
+  type Output = u64;
+  fn add(self: u64, arg: u64) -> Self#Add<u64>::Output {
+    self + arg
+  }
+}
+
+fn try_add<S, T>(s: S, t: T) -> S#Add<T>::Output where S: Add<T> {
+  s.add(t)
+}
+
+fn main() -> void {
+  5.add(6);
+  try_add(9, 1);
+}

--- a/examples/generics_trait.niu
+++ b/examples/generics_trait.niu
@@ -5,7 +5,7 @@ trait Add<Arg> {
 
 impl Add<u64> for u64 {
   type Output = u64;
-  fn add(self: u64, arg: u64) -> Self#Add<u64>::Output {
+  fn add(self: u64, arg: u64) -> u64#Add<u64>::Output {
     self + arg
   }
 }

--- a/examples/generics_trait.niu
+++ b/examples/generics_trait.niu
@@ -5,7 +5,7 @@ trait Add<Arg> {
 
 impl Add<u64> for u64 {
   type Output = u64;
-  fn add(self: u64, arg: u64) -> u64#Add<u64>::Output {
+  fn add(self: Self, arg: u64) -> Self#Add<u64>::Output {
     self + arg
   }
 }

--- a/src/func_definition.rs
+++ b/src/func_definition.rs
@@ -67,7 +67,7 @@ impl FuncDefinitionInfo {
         Ok(Type::Func(args, Box::new(return_type), type_info))
     }
 
-    pub fn check_equal(&self, right: &Self, equs: &mut TypeEquations, trs: &TraitsInfo) -> Result<(), String> {
+    pub fn check_equal(&self, right: &Self, equs: &mut TypeEquations, trs: &TraitsInfo, self_gen_map: &GenericsTypeMap, right_gen_map: &GenericsTypeMap) -> Result<(), String> {
         if self.generics != right.generics {
             Err(format!("generics of method {:?} is not matched", self.func_id))?;
         }
@@ -78,10 +78,10 @@ impl FuncDefinitionInfo {
         for g_id in self.generics.iter() {
             trs.regist_generics_type(g_id)?;
         }
-        let self_args  =  self.args.iter().map(|(_, t)| t.generics_to_type(&GenericsTypeMap::empty(), equs, &trs)).collect::<Result<Vec<Type>, String>>()?;
-        let right_args = right.args.iter().map(|(_, t)| t.generics_to_type(&GenericsTypeMap::empty(), equs, &trs)).collect::<Result<Vec<Type>, String>>()?;
-        let self_return_type = self.return_type.generics_to_type(&GenericsTypeMap::empty(), equs, &trs)?;
-        let right_return_type = right.return_type.generics_to_type(&GenericsTypeMap::empty(), equs, &trs)?;
+        let self_args  =  self.args.iter().map(|(_, t)| t.generics_to_type(self_gen_map, equs, &trs)).collect::<Result<Vec<Type>, String>>()?;
+        let right_args = right.args.iter().map(|(_, t)| t.generics_to_type(right_gen_map, equs, &trs)).collect::<Result<Vec<Type>, String>>()?;
+        let self_return_type = self.return_type.generics_to_type(self_gen_map, equs, &trs)?;
+        let right_return_type = right.return_type.generics_to_type(right_gen_map, equs, &trs)?;
         equs.add_equation(
             Type::Func(self_args, Box::new(self_return_type), FuncTypeInfo::None),
             Type::Func(right_args, Box::new(right_return_type), FuncTypeInfo::None)

--- a/src/func_definition.rs
+++ b/src/func_definition.rs
@@ -195,7 +195,7 @@ impl FuncDefinition {
         let template_str =
             if self.generics.len() > 0 {
                 let gen = self.generics.iter().map(|g| format!("class {}", g.transpile(ta))).collect::<Vec<_>>().join(", ");
-                if !where_empty  {
+                if where_empty  {
                     format!("template<{}> ", gen)
                 }
                 else {

--- a/src/structs/impl_self.rs
+++ b/src/structs/impl_self.rs
@@ -70,7 +70,7 @@ impl ImplSelfDefinition {
 
 impl ImplSelfCandidate {
     pub fn generate_equations_for_call_equation(&self, call_eq: &CallEquation, trs: &TraitsInfo) -> Result<TypeEquations, String> {
-        if call_eq.trait_id != None {
+        if call_eq.trait_gen != None {
             return Err(format!("trait_id is not matched"))
         }
         let mut equs = TypeEquations::new();

--- a/src/subseq.rs
+++ b/src/subseq.rs
@@ -108,11 +108,13 @@ pub fn subseq_transpile(uexpr: &UnaryExpr, subseq: &Subseq, ta: &TypeAnnotation)
                 //if let Type::Func(_, _, Some((trait_id, ty))) = ty {
                 if let Type::Func(_, _, info) = ty {
                     match info {
-                        FuncTypeInfo::TraitFunc(trait_id, tag) => {
+                        FuncTypeInfo::TraitFunc(trait_id, generics_cnt, tag) => {
                             let args = call.args.iter().map(|arg| arg.transpile(ta));
                             let args = std::iter::once(caller_trans).chain(args).collect::<Vec<_>>().join(", ");
-                            let ty = ta.annotation(tag.get_num(), "SelfType", 0);
-                            format!("{}<{}>::{}({})", trait_id.transpile(ta), ty.transpile(ta), mem.mem_id.into_string(), args)
+                            let ty = std::iter::once(ta.annotation(tag.get_num(), "SelfType", 0)).chain(
+                                (0..generics_cnt).map(|i| ta.annotation(tag.get_num(), "TraitGenerics", i)))
+                                .map(|t| t.transpile(ta)).collect::<Vec<_>>().join(", ");
+                            format!("{}<{}>::{}({})", trait_id.transpile(ta), ty, mem.mem_id.into_string(), args)
                         }
                         FuncTypeInfo::SelfFunc(tag) => {
                             let ty = ta.annotation(tag.get_num(), "SelfType", 0).transpile(ta);
@@ -140,11 +142,13 @@ pub fn subseq_transpile(uexpr: &UnaryExpr, subseq: &Subseq, ta: &TypeAnnotation)
                 //if let Type::Func(_, _, Some((trait_id, ty))) = ty {
                 if let Type::Func(_, _, info) = ty {
                     match info {
-                        FuncTypeInfo::TraitFunc(trait_id, tag) => {
+                        FuncTypeInfo::TraitFunc(trait_id, generics_cnt, tag) => {
                             let args = call.args.iter().map(|arg| arg.transpile(ta));
                             let args = args.collect::<Vec<_>>().join(", ");
-                            let ty = ta.annotation(tag.get_num(), "SelfType", 0);
-                            format!("{}<{}>::{}({})", trait_id.transpile(ta), ty.transpile(ta), method_id.into_string(), args)
+                            let ty = std::iter::once(ta.annotation(tag.get_num(), "SelfType", 0)).chain(
+                                (0..generics_cnt).map(|i| ta.annotation(tag.get_num(), "TraitGenerics", i)))
+                                .map(|t| t.transpile(ta)).collect::<Vec<_>>().join(", ");
+                            format!("{}<{}>::{}({})", trait_id.transpile(ta), ty, method_id.into_string(), args)
                         }
                         FuncTypeInfo::SelfFunc(tag) => {
                             let ty = ta.annotation(tag.get_num(), "SelfType", 0).transpile(ta);

--- a/src/subseq.rs
+++ b/src/subseq.rs
@@ -35,7 +35,7 @@ pub fn subseq_gen_type(uexpr: &UnaryExpr, subseq: &Subseq, equs: &mut TypeEquati
                             .chain(call.args.iter().map(|arg| arg.gen_type(equs, trs))).collect::<Result<Vec<_>, String>>()?;
                     Ok(Type::CallEquation(CallEquation {
                         caller_type: None,
-                        trait_id: None,
+                        trait_gen: None,
                         func_id: mem.mem_id.clone(),
                         args,
                         tag: call.tag.clone(),
@@ -46,7 +46,7 @@ pub fn subseq_gen_type(uexpr: &UnaryExpr, subseq: &Subseq, equs: &mut TypeEquati
                     let args = call.args.iter().map(|arg| arg.gen_type(equs, trs)).collect::<Result<Vec<_>, String>>()?;
                     Ok(Type::CallEquation(CallEquation {
                         caller_type: Some(Box::new(caller)),
-                        trait_id: trait_op.clone(),
+                        trait_gen: trait_op.clone(),
                         func_id: func_id.clone(),
                         args,
                         tag: call.tag.clone(),
@@ -80,7 +80,7 @@ pub fn subseq_gen_type(uexpr: &UnaryExpr, subseq: &Subseq, equs: &mut TypeEquati
             Ok(Type::Deref(Box::new(
                         Type::CallEquation(CallEquation {
                             caller_type: Some(Box::new(caller)),
-                            trait_id: Some(TraitId { id: Identifier::from_str("Index") }),
+                            trait_gen: Some(TraitId { id: Identifier::from_str("Index") }),
                             func_id: Identifier::from_str("index"),
                             args: vec![arg0, arg1],
                             tag: index.tag.clone(),

--- a/src/subseq.rs
+++ b/src/subseq.rs
@@ -46,7 +46,10 @@ pub fn subseq_gen_type(uexpr: &UnaryExpr, subseq: &Subseq, equs: &mut TypeEquati
                     let args = call.args.iter().map(|arg| arg.gen_type(equs, trs)).collect::<Result<Vec<_>, String>>()?;
                     Ok(Type::CallEquation(CallEquation {
                         caller_type: Some(Box::new(caller)),
-                        trait_gen: trait_op.clone(),
+                        trait_gen: match trait_op {
+                            Some(trait_spec) => Some(trait_spec.generate_trait_generics_with_no_map(equs, trs)?),
+                            None => None,
+                        },
                         func_id: func_id.clone(),
                         args,
                         tag: call.tag.clone(),
@@ -80,7 +83,7 @@ pub fn subseq_gen_type(uexpr: &UnaryExpr, subseq: &Subseq, equs: &mut TypeEquati
             Ok(Type::Deref(Box::new(
                         Type::CallEquation(CallEquation {
                             caller_type: Some(Box::new(caller)),
-                            trait_gen: Some(TraitId { id: Identifier::from_str("Index") }),
+                            trait_gen: Some(TraitGenerics { trait_id: TraitId { id: Identifier::from_str("Index") }, generics: Vec::new() }),
                             func_id: Identifier::from_str("index"),
                             args: vec![arg0, arg1],
                             tag: index.tag.clone(),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -43,7 +43,7 @@ pub fn parse_trait_id(s: &str) -> IResult<&str, TraitId> {
     Ok((s, TraitId { id }))
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct TraitSpec {
     pub trait_id: TraitId,
     pub generics: Vec<TypeSpec>,
@@ -56,6 +56,11 @@ impl TraitSpec {
     pub fn generate_trait_generics(&self, equs: &mut TypeEquations, trs: &TraitsInfo, gen_mp: &GenericsTypeMap) -> Result<TraitGenerics, String> {
         trs.check_trait(self)?;
         let generics = self.generics.iter().map(|g| g.generics_to_type(gen_mp, equs, trs)).collect::<Result<Vec<_>, String>>()?;
+        Ok(TraitGenerics { trait_id: self.trait_id.clone(), generics })
+    }
+    pub fn generate_trait_generics_with_no_map(&self, equs: &TypeEquations, trs: &TraitsInfo) -> Result<TraitGenerics, String> {
+        trs.check_trait(self)?;
+        let generics = self.generics.iter().map(|g| g.generate_type_no_auto_generics(equs, trs)).collect::<Result<Vec<_>, String>>()?;
         Ok(TraitGenerics { trait_id: self.trait_id.clone(), generics })
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -110,7 +110,8 @@ impl TraitDefinition {
 
 impl Transpile for TraitDefinition {
     fn transpile(&self, ta: &TypeAnnotation) -> String {
-        format!("template<class Self, class = void> struct {}: std::false_type {{ }};\n", self.trait_id.transpile(ta))
+        let generics = self.generics.iter().map(|g| format!("class {}, ", g.transpile(ta))).collect::<Vec<_>>().join("");
+        format!("template<class Self, {}class = void> struct {}: std::false_type {{ }};\n", generics, self.trait_id.transpile(ta))
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -18,7 +18,7 @@ use nom::multi::*;
 use nom::sequence::*;
 use nom::IResult;
 
-use crate::identifier::{ Identifier, parse_identifier };
+use crate::identifier::{ Identifier, parse_identifier, Tag };
 //use crate::unary_expr::Variable;
 use crate::unify::where_section::*;
 use crate::unify::*;
@@ -47,6 +47,17 @@ pub fn parse_trait_id(s: &str) -> IResult<&str, TraitId> {
 pub struct TraitSpec {
     pub trait_id: TraitId,
     pub generics: Vec<TypeSpec>,
+}
+
+impl TraitSpec {
+    pub fn get_tag(&self) -> Tag {
+        self.trait_id.id.tag.clone()
+    }
+    pub fn generate_trait_generics(&self, equs: &mut TypeEquations, trs: &TraitsInfo, gen_mp: &GenericsTypeMap) -> Result<TraitGenerics, String> {
+        trs.check_trait(self)?;
+        let generics = self.generics.iter().map(|g| g.generics_to_type(gen_mp, equs, trs)).collect::<Result<Vec<_>, String>>()?;
+        Ok(TraitGenerics { trait_id: self.trait_id.clone(), generics })
+    }
 }
 
 fn parse_generics_args(s: &str) -> IResult<&str, Vec<TypeId>> {

--- a/src/traits/associated_type.rs
+++ b/src/traits/associated_type.rs
@@ -26,13 +26,13 @@ pub fn parse_associated_type_identifier(s: &str) -> IResult<&str, AssociatedType
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AssociatedType {
-    pub trait_id: TraitId,
+    pub trait_spec: TraitSpec,
     pub type_id: AssociatedTypeIdentifier,
 }
 
 pub fn parse_associated_type(s: &str) -> IResult<&str, AssociatedType> {
-    let (s, (trait_id, _, _, _, type_id)) = tuple((parse_trait_id, multispace0, tag("::"), multispace0, parse_associated_type_identifier))(s)?;
-    Ok((s, AssociatedType { trait_id, type_id }))
+    let (s, (trait_spec, _, _, _, type_id)) = tuple((parse_trait_spec, multispace0, tag("::"), multispace0, parse_associated_type_identifier))(s)?;
+    Ok((s, AssociatedType { trait_spec, type_id }))
 }
 
 

--- a/src/type_spec.rs
+++ b/src/type_spec.rs
@@ -295,7 +295,9 @@ impl Transpile for TypeSpec {
                 format!("{}*", spec.transpile(ta))
             }
             TypeSpec::Associated(ref spec, AssociatedType { ref trait_spec, ref type_id } ) => {
-                format!("typename {}<{}>::{}", trait_spec.trait_id.transpile(ta), spec.transpile(ta), type_id.transpile(ta))
+                let generics = std::iter::once(spec.transpile(ta)).chain(trait_spec.generics.iter().map(|g| g.transpile(ta)))
+                    .collect::<Vec<_>>().join(", ");
+                format!("typename {}<{}>::{}", trait_spec.trait_id.transpile(ta), generics, type_id.transpile(ta))
             }
         }
                 

--- a/src/type_spec.rs
+++ b/src/type_spec.rs
@@ -57,7 +57,10 @@ impl TypeSign {
             _ => {
                 if self.id == TypeId::from_str("Self") {
                     if self.gens.len() == 0 {
-                        equs.get_self_type()
+                       let self_type = equs.get_self_type()?;
+                       let alpha = self.id.id.generate_type_variable("SelfId", 0, equs);
+                       equs.add_equation(self_type.clone(), alpha);
+                       Ok(self_type)
                     }
                     else {
                         Err(format!("Self cant have generics arg"))
@@ -148,12 +151,12 @@ impl Transpile for TypeSign {
             else {
                 format!("")
             };
-            /* let ty = if self.id == TypeId::from_str("Self") {
-               ta.annotation(self.id.id.get_tag_number(), 0).transpile(ta)
-               } else {
-
-               }; */
-            format!("{}{}", self.id.transpile(ta), gens_trans)
+            let ty = if self.id == TypeId::from_str("Self") {
+                ta.annotation(self.id.id.get_tag_number(), "SelfId", 0).transpile(ta)
+            } else {
+                self.id.transpile(ta)
+            };
+            format!("{}{}", ty, gens_trans)
         }
     }
 }

--- a/src/type_spec.rs
+++ b/src/type_spec.rs
@@ -179,7 +179,8 @@ impl TypeSpec {
                 Ok(Type::MutRef(Box::new(spec.as_ref().generics_to_type(mp, equs, trs)?)))
             }
             TypeSpec::Associated(ref spec, ref asso) => {
-                Ok(Type::AssociatedType(Box::new(spec.as_ref().generics_to_type(mp, equs, trs)?), asso.clone()))
+                let trait_gen = asso.trait_spec.generate_trait_generics(equs, trs, mp)?;
+                Ok(Type::AssociatedType(Box::new(spec.as_ref().generics_to_type(mp, equs, trs)?), trait_gen, asso.type_id.clone()))
             }
         }
     }
@@ -196,7 +197,8 @@ impl TypeSpec {
                 Ok(Type::Ref(Box::new(spec.as_ref().generate_type_no_auto_generics(equs, trs)?)))
             }
             TypeSpec::Associated(ref spec, ref asso) => {
-                Ok(Type::AssociatedType(Box::new(spec.as_ref().generate_type_no_auto_generics(equs, trs)?), asso.clone()))
+                let trait_gen = asso.trait_spec.generate_trait_generics_with_no_map(equs, trs)?;
+                Ok(Type::AssociatedType(Box::new(spec.as_ref().generate_type_no_auto_generics(equs, trs)?), trait_gen, asso.type_id.clone()))
             }
         }
     }
@@ -292,8 +294,8 @@ impl Transpile for TypeSpec {
             TypeSpec::MutPointer(ref spec) => {
                 format!("{}*", spec.transpile(ta))
             }
-            TypeSpec::Associated(ref spec, AssociatedType { ref trait_id, ref type_id } ) => {
-                format!("typename {}<{}>::{}", trait_id.transpile(ta), spec.transpile(ta), type_id.transpile(ta))
+            TypeSpec::Associated(ref spec, AssociatedType { ref trait_spec, ref type_id } ) => {
+                format!("typename {}<{}>::{}", trait_spec.trait_id.transpile(ta), spec.transpile(ta), type_id.transpile(ta))
             }
         }
                 

--- a/src/unify/traits_info.rs
+++ b/src/unify/traits_info.rs
@@ -205,6 +205,22 @@ impl<'a> TraitsInfo<'a> {
         }
     }
 
+    pub fn check_trait(&self, tr: &TraitSpec) -> Result<(), String> {
+        match self.traits.get(&tr.trait_id) {
+            None => {
+                Err(format!("trait {:?} not found", tr))
+            }
+            Some(tr_def) => {
+                if tr_def.generics.len() == tr.generics.len() {
+                    Ok(())
+                }
+                else {
+                    Err(format!("Generics of {:?} is not match to trait {:?}", tr, tr.trait_id))
+                }
+            }
+        }
+    }
+
     pub fn regist_trait(&mut self, tr: &TraitDefinition) -> Result<(), String> {
         let (trait_id, trait_def) = tr.get_trait_id_pair();
         for (id, _) in trait_def.required_methods.iter() {

--- a/src/unify/type_equation.rs
+++ b/src/unify/type_equation.rs
@@ -127,10 +127,10 @@ impl Type {
                 }
                 false
             }
-            Type::AssociatedType(ref ty, tr, _) => {
+            Type::AssociatedType(ref ty, ref tr, _) => {
                 ty.as_ref().occurs(t) || tr.occurs(t)
             }
-            Type::SolvedAssociatedType(ref ty, tr, _) => {
+            Type::SolvedAssociatedType(ref ty, ref tr, _) => {
                 ty.as_ref().occurs(t) || tr.occurs(t)
             }
             Type::TraitMethod(ref ty, _, _) => {

--- a/src/unify/type_equation.rs
+++ b/src/unify/type_equation.rs
@@ -216,7 +216,8 @@ impl Transpile for Type {
     fn transpile(&self, ta: &TypeAnnotation) -> String {
         match *self {
             Type::SolvedAssociatedType(ref ty, ref tr, ref asso_id) => {
-                format!("typename {}<{}>::{}", tr.trait_id.transpile(ta), ty.as_ref().transpile(ta), asso_id.transpile(ta))
+                let generics = std::iter::once(ty.transpile(ta)).chain(tr.generics.iter().map(|g| g.transpile(ta))).collect::<Vec<_>>().join(", ");
+                format!("typename {}<{}>::{}", tr.trait_id.transpile(ta), generics, asso_id.transpile(ta))
             }
             Type::Ref(ref ty) => {
                 format!("{}*", ty.as_ref().transpile(ta))

--- a/src/unify/type_equation.rs
+++ b/src/unify/type_equation.rs
@@ -849,23 +849,23 @@ impl TypeEquations {
                                     _ => Some((ref_tag, tmp_equs)),
                                 }
                             ).collect::<Vec<_>>();
-                            log::debug!("--------------------");
-                            log::debug!("AUTOREF {:?} : {:?} {:?}", left, ty, tag);
-                            log::debug!("oks = {:?}", oks);
+                            //log::debug!("--------------------");
+                            //log::debug!("AUTOREF {:?} : {:?} {:?}", left, ty, tag);
+                            //log::debug!("oks = {:?}", oks);
                             if oks.len() == 0 {
                                 Err(UnifyErr::Contradiction(format!("not equal {:?}, auto ref {:?}", left, ty)))?;
                             }
                             if oks.len() == 1 {
-                                log::debug!("OK");
-                                log::debug!("--------------------");
+                                //log::debug!("OK");
+                                //log::debug!("--------------------");
                                 let (ref_tag, tmp_equs) = oks.pop().unwrap();
                                 self.take_over_equations(tmp_equs);
                                 let var = tag.generate_type_variable("AutoRefType", 0, self);
                                 self.add_equation(var, Type::AutoRef(Box::new(ty), ref_tag));
                             }
                             else {
-                                log::debug!("NG");
-                                log::debug!("--------------------");
+                                //log::debug!("NG");
+                                //log::debug!("--------------------");
                                 self.equs.push_back(TypeEquation::Equal(left, Type::AutoRef(Box::new(ty), AutoRefTag::Tag(tag)), changed & ty_changed));
                             }
                         }

--- a/src/unify/type_equation.rs
+++ b/src/unify/type_equation.rs
@@ -42,7 +42,7 @@ impl CppInlineInfo {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FuncTypeInfo {
-    TraitFunc(TraitId, Tag),
+    TraitFunc(TraitId, usize, Tag),
     SelfFunc(Tag),
     CppInline(CppInlineInfo, Vec<Identifier>),
     None,

--- a/src/unify/where_section.rs
+++ b/src/unify/where_section.rs
@@ -15,7 +15,7 @@ use crate::trans::*;
 
 #[derive(Debug, Clone)]
 pub struct WhereSection {
-    has_traits: Vec<(TypeSpec, usize, TraitId, Vec<(AssociatedTypeIdentifier, TypeSpec)>)>,
+    has_traits: Vec<(TypeSpec, usize, TraitSpec, Vec<(AssociatedTypeIdentifier, TypeSpec)>)>,
 }
 
 impl WhereSection {
@@ -26,11 +26,12 @@ impl WhereSection {
         self.has_traits.is_empty()
     }
     pub fn regist_equations(&self, mp: &GenericsTypeMap, equs: &mut TypeEquations, trs: &TraitsInfo) -> Result<(), String> {
-        for (spec, _, tr_id, asso_eqs) in self.has_traits.iter() {
+        for (spec, _, tr_spec, asso_eqs) in self.has_traits.iter() {
             let ty = spec.generics_to_type(mp, equs, trs)?;
-            equs.add_has_trait(ty.clone(), tr_id.clone());
+            let tr_gen = tr_spec.generate_trait_generics(equs, trs, mp)?;
+            equs.add_has_trait(ty.clone(), tr_gen.clone());
             for (asso_id, asso_spec) in asso_eqs.iter() {
-                let asso_ty = Type::AssociatedType(Box::new(ty.clone()), AssociatedType { trait_id: tr_id.clone(), type_id: asso_id.clone() });
+                let asso_ty = Type::AssociatedType(Box::new(ty.clone()), tr_gen.clone(), asso_id.clone());
                 let asso_spec_ty = asso_spec.generics_to_type(mp, equs, trs)?;
                 equs.add_equation(asso_ty, asso_spec_ty)
             }
@@ -39,14 +40,16 @@ impl WhereSection {
     }
 
     pub fn regist_candidate(&self, equs: &TypeEquations, trs: &mut TraitsInfo) -> Result<(), String> {
-        for (spec, _, tr_id, asso_eqs) in self.has_traits.iter() {
+        for (spec, _, tr_spec, asso_eqs) in self.has_traits.iter() {
 
 
             let mut tmp_equs = TypeEquations::new();
 
             let param_ty = spec.generate_type_no_auto_generics(equs, trs)?;
-            let alpha = tr_id.id.generate_type_variable("ParamType", 0, &mut tmp_equs);
+            let alpha = tr_spec.get_tag().generate_type_variable("ParamType", 0, &mut tmp_equs);
             tmp_equs.add_equation(param_ty, alpha);
+
+            let tr_gen = tr_spec.generate_trait_generics_with_no_map(equs, trs)?;
 
             for (asso_id, asso_spec) in asso_eqs.iter() {
                 let asso_spec_ty = asso_spec.generate_type_no_auto_generics(&equs, trs)?;
@@ -56,13 +59,13 @@ impl WhereSection {
             tmp_equs.unify(trs).map_err(|err| err.to_string())?;
             let substs = SubstsMap::new(tmp_equs.take_substs().clone());
 
-            let param_ty = substs.get(&tr_id.id, "ParamType", 0)?;
+            let param_ty = substs.get_from_tag(&tr_spec.get_tag(), "ParamType", 0)?;
             let asso_mp = asso_eqs.iter().map(|(asso_id, _)| {
                     let asso_spec_ty = substs.get(&asso_id.id, "AssociatedType", 0)?;
                     Ok((asso_id.clone(), asso_spec_ty))
                 }).collect::<Result<HashMap<_, _>, String>>()?;
             
-            trs.regist_param_candidate(param_ty, tr_id, asso_mp)?;
+            trs.regist_param_candidate(param_ty, &tr_gen, asso_mp)?;
             
         }
         Ok(())
@@ -76,7 +79,7 @@ impl WhereSection {
     pub fn transpile(&self, ta: &TypeAnnotation) -> String {
         let mut conds = Vec::new();
         for (ty, _, tr, assos) in self.has_traits.iter() {
-            let trait_ty = format!("{}<{}>", tr.transpile(ta), ty.transpile(ta));
+            let trait_ty = format!("{}<{}>", tr.trait_id.transpile(ta), ty.transpile(ta));
             conds.push(trait_ty.clone());
             for (id, asso_ty) in assos.iter() {
                 conds.push(format!("std::is_same<typename {}::{}, {}>", trait_ty.clone(), id.transpile(ta), asso_ty.transpile(ta)));
@@ -105,8 +108,8 @@ fn parse_associated_type_specifiers(s: &str) -> IResult<&str, Vec<(AssociatedTyp
     Ok((s, res))
 }
 
-fn parse_has_trait_element(s: &str) -> IResult<&str, (TypeSpec, usize, TraitId, Vec<(AssociatedTypeIdentifier, TypeSpec)>)> {
-    let (s, (spec, _, _, _, tr_id, _, assos)) = tuple((parse_type_spec, multispace0, char(':'), multispace0, parse_trait_id, multispace0, parse_associated_type_specifiers))(s)?;
+fn parse_has_trait_element(s: &str) -> IResult<&str, (TypeSpec, usize, TraitSpec, Vec<(AssociatedTypeIdentifier, TypeSpec)>)> {
+    let (s, (spec, _, _, _, tr_id, _, assos)) = tuple((parse_type_spec, multispace0, char(':'), multispace0, parse_trait_spec, multispace0, parse_associated_type_specifiers))(s)?;
     let dep = spec.associated_type_depth();
     Ok((s, (spec, dep, tr_id, assos)))
 }

--- a/src/unify/where_section.rs
+++ b/src/unify/where_section.rs
@@ -79,7 +79,8 @@ impl WhereSection {
     pub fn transpile(&self, ta: &TypeAnnotation) -> String {
         let mut conds = Vec::new();
         for (ty, _, tr, assos) in self.has_traits.iter() {
-            let trait_ty = format!("{}<{}>", tr.trait_id.transpile(ta), ty.transpile(ta));
+            let generics = std::iter::once(ty.transpile(ta)).chain(tr.generics.iter().map(|g| g.transpile(ta))).collect::<Vec<_>>().join(", ");
+            let trait_ty = format!("{}<{}>", tr.trait_id.transpile(ta), generics);
             conds.push(trait_ty.clone());
             for (id, asso_ty) in assos.iter() {
                 conds.push(format!("std::is_same<typename {}::{}, {}>", trait_ty.clone(), id.transpile(ta), asso_ty.transpile(ta)));


### PR DESCRIPTION
#22 これのために実装した

```
trait Add<Arg> {
  type Output;
  fn add(self: Self, arg: Arg) -> Self#Add<Arg>::Output;
}

impl Add<u64> for u64 {
  type Output = u64;
  fn add(self: Self, arg: u64) -> Self#Add<u64>::Output {
    self + arg
  }
}

fn try_add<S, T>(s: S, t: T) -> S#Add<T>::Output where S: Add<T> {
  let ans = s.add(t);
  ans
}

fn main() -> void {
  5.add(6);
  try_add(9, 1);
}
```
が書けるようになった