### PR TITLE
Fix about Index

### DIFF
--- a/lib/data_structure/segment_tree.niu
+++ b/lib/data_structure/segment_tree.niu
@@ -1,4 +1,7 @@
 import "std/vec.niu"
+import "std/u64.niu"
+import "std/i64.niu"
+
 trait Monoid {
   fn ide() -> Self;
   fn ope(self: &Self, right: &Self) -> Self;
@@ -18,22 +21,22 @@ struct SegmentTree<T> where T: Monoid {
     for(n = 1; n < arr.len(); n = n * 2) {};
     let mut node = Vec::init(2 * n, T#Monoid::ide());
     for(let mut i = 0; i < arr.len(); i = i + 1) {
-      *node.index_mut(i + n) = *arr.index(i);
+      node[i + n] = arr[i];
     };
     for(let mut i = n - 1; i >= 1; i = i - 1) {
-      *node.index_mut(i) = node.index(i * 2).ope(node.index(i * 2 + 1));
+      node[i] = node[i * 2].ope(&node[i * 2 + 1]);
     };
     SegmentTree { node: node, n: n, }
   }
 
   fn get(self: &Self, i: u64) -> &T {
-    self.node.index(i + self.n)
+    &self.node[i + self.n]
   }
 
   fn update(self: &mut Self, p: u64, x: T) -> void {
-    *self.node.index_mut(p + self.n) = x;
+    self.node[p + self.n] = x;
     for(let mut i = (p + self.n) / 2; i >= 1; i = i / 2) {
-      *self.node.index_mut(i) = self.node.index(i * 2).ope(self.node.index(i * 2 + 1));
+      self.node[i] = self.node[i * 2].ope(&self.node[i * 2 + 1]);
     };
   }
 
@@ -43,12 +46,12 @@ struct SegmentTree<T> where T: Monoid {
     let mut i = l + self.n;
     for(let mut j = r + self.n; i < j; j = j >> 1) {
       if (i & 1) == 1 {
-        lx = lx.ope(self.node.index(i));
+        lx = lx.ope(&self.node[i]);
         i = i + 1;
       } else {};
       if (j & 1) == 1 {
         j = j - 1;
-        rx = self.node.index(j).ope(&rx);
+        rx = self.node[j].ope(&rx);
       } else {};
       i = i >> 1;
     };

--- a/lib/data_structure/union_find.niu
+++ b/lib/data_structure/union_find.niu
@@ -1,4 +1,6 @@
 import "std/vec.niu"
+import "std/u64.niu"
+
 struct UnionFind {
   par: Vec<u64>,
   sz: Vec<u64>,
@@ -14,17 +16,17 @@ struct UnionFind {
     UnionFind { par: par, sz: sz, N: N, }
   }
   fn root(self: &mut Self, x: u64) -> u64 {
-    if *self.par.index(x) == self.N {
+    if self.par[x] == self.N {
       x
     }
     else {
-      let r = self.root(*self.par.index(x));
-      *self.par.index_mut(x) = r;
+      let r = self.root(self.par[x]);
+      self.par[x] = r;
       r
     }
   }
   fn size(self: &mut Self, x: u64) -> u64 {
-    *self.sz.index(self.root(x))
+    self.sz[self.root(x)]
   }
   fn unite(self: &mut Self, x: u64, y: u64) -> void {
     let xr = self.root(x);
@@ -33,12 +35,12 @@ struct UnionFind {
       let xs = self.size(xr);
       let ys = self.size(yr);
       if xs < ys {
-        *self.sz.index_mut(yr) = ys + xs;
-        *self.par.index_mut(xr) = yr;
+        self.sz[yr] = ys + xs;
+        self.par[xr] = yr;
       }
       else {
-        *self.sz.index_mut(xr) = ys + xs;
-        *self.par.index_mut(yr) = xr;
+        self.sz[xr] = ys + xs;
+        self.par[yr] = xr;
       };
     }
     else {

--- a/lib/math/modint.niu
+++ b/lib/math/modint.niu
@@ -1,0 +1,27 @@
+import "std/u64.niu"
+import "std/opes.niu"
+
+trait Mod {
+  fn m() -> u64;
+}
+
+struct M9982 {} {}
+
+impl Mod for M9982 {
+  fn m() -> u64 { 998244353 }
+}
+
+struct Modint<M> where M: Mod {
+  a: u64
+} {
+  fn init(a: u64) -> Self {
+    Modint { a: a }
+  }
+}
+
+impl<M> Add<Modint<M>> for Modint<M> where M: Mod {
+  type Output = Self;
+  fn add(self: Self, right: Self) -> Self {
+    Modint { a: (self.a + right.a) % M::m() }
+  }
+}

--- a/lib/std/i64.niu
+++ b/lib/std/i64.niu
@@ -1,0 +1,42 @@
+import "opes.niu"
+
+impl BitOr<i64> for i64 {
+  type Output = i64;
+  fn bit_or(a: Self, b: i64) -> i64 $${a | b}$$
+}
+impl BitXor<i64> for i64 {
+  type Output = i64;
+  fn bit_xor(a: Self, b: i64) -> i64 $${a ^ b}$$
+}
+impl BitAnd<i64> for i64 {
+  type Output = i64;
+  fn bit_and(a: Self, b: i64) -> i64 $${a & b}$$
+}
+impl Shl<i64> for i64 {
+  type Output = i64;
+  fn shl(a: Self, b: i64) -> i64 $${a << b}$$
+}
+impl Shr<i64> for i64 {
+  type Output = i64;
+  fn shr(a: Self, b: i64) -> i64 $${a >> b}$$
+}
+impl Add<i64> for i64 {
+  type Output = i64;
+  fn add(a: Self, b: i64) -> i64 $${a + b}$$
+}
+impl Sub<i64> for i64 {
+  type Output = i64;
+  fn sub(a: Self, b: i64) -> i64 $${a - b}$$
+}
+impl Mul<i64> for i64 {
+  type Output = i64;
+  fn mul(a: Self, b: i64) -> i64 $${a * b}$$
+}
+impl Div<i64> for i64 {
+  type Output = i64;
+  fn div(a: Self, b: i64) -> i64 $${a / b}$$
+}
+impl Rem<i64> for i64 {
+  type Output = i64;
+  fn rem(a: Self, b: i64) -> i64 $${a % b}$$
+}

--- a/lib/std/vec.niu
+++ b/lib/std/vec.niu
@@ -1,9 +1,19 @@
+import "std/opes.niu"
+
 struct Vec<T> $${std::vector<$ty(T)>}$$ {
   fn new() -> Self $${std::vector<$ty(T)>()}$$
   fn init(N: u64, t: T) -> Self $${std::vector<$ty(T)>($arg(N), $arg(t))}$$
   fn push(self: &mut Self, t: T) -> void $${$arg(self)->push_back($arg(t))}$$
   fn len(self: &Self) -> u64 $${$arg(self)->size()}$$
-  fn index(self: &Self, i: u64) -> &T $${(&$arg(self)->at($arg(i)))}$$
-  fn index_mut(self: &mut Self, i: u64) -> &mut T $${(&$arg(self)->at($arg(i)))}$$
   fn pop(self: &mut Self) -> void $${$arg(self)->pop_back()}$$
+}
+
+impl<T> Index for Vec<T> {
+  type Output = T;
+  type Arg = u64;
+  fn index(self: &Self, i: u64) -> &T $${(&$arg(self)->at($arg(i)))}$$
+}
+
+impl<T> IndexMut for Vec<T> {
+  fn index_mut(self: &mut Self, i: u64) -> &mut T $${(&$arg(self)->at($arg(i)))}$$
 }

--- a/src/func_definition.rs
+++ b/src/func_definition.rs
@@ -86,7 +86,7 @@ impl FuncDefinitionInfo {
             Type::Func(self_args, Box::new(self_return_type), FuncTypeInfo::None),
             Type::Func(right_args, Box::new(right_return_type), FuncTypeInfo::None)
             );
-        log::debug!("function {:?} and {:?} are equal unify", self.func_id, right.func_id);
+        log::info!("function {:?} and {:?} are equal unify", self.func_id, right.func_id);
         equs.unify(&mut trs).map_err(|err| err.to_string())?;
         Ok(())
     }
@@ -167,7 +167,7 @@ impl FuncDefinition {
             let return_t = self.return_type.generics_to_type(&GenericsTypeMap::empty(), equs, &trs)?;
             equs.add_equation(result_type, return_t);
 
-            log::debug!("function {:?} unify", self.func_id);
+            log::info!("function {:?} unify", self.func_id);
             //equs.debug();
             let result = equs.unify(&mut trs);
 

--- a/src/subseq.rs
+++ b/src/subseq.rs
@@ -82,7 +82,7 @@ pub fn subseq_gen_type(uexpr: &UnaryExpr, subseq: &Subseq, equs: &mut TypeEquati
             let arg1 = index.arg.as_ref().gen_type(equs, trs)?;
             Ok(Type::Deref(Box::new(
                         Type::CallEquation(CallEquation {
-                            caller_type: Some(Box::new(caller)),
+                            caller_type: None,
                             trait_gen: Some(TraitGenerics { trait_id: TraitId { id: Identifier::from_str("Index") }, generics: Vec::new() }),
                             func_id: Identifier::from_str("index"),
                             args: vec![arg0, arg1],

--- a/src/unify/traits_info.rs
+++ b/src/unify/traits_info.rs
@@ -486,7 +486,7 @@ impl<'a> TraitsInfo<'a> {
             let vs = self.generate_call_equations_for_trait(&t, call_eq, self);
             let mut vs = vs.into_iter().filter_map(|(mut equs, cand, pri)| {
                 //log::debug!("{:?}", equs);
-                match dbg!(equs.unify(self)) {
+                match equs.unify(self) {
                     Ok(_) => Some((equs, cand, pri)),
                     Err(UnifyErr::Deficiency(_)) => Some((equs, cand, pri)),
                     Err(UnifyErr::Contradiction(_)) => None


### PR DESCRIPTION
- `t: &T`でIndexトレイトを持っている時に`t[i]`するとうまく`index`が呼び出されないバグを修正
- `std/vec.niu`をIndex/IndexMutに対応