### PR TITLE
add float type

### DIFF
--- a/examples/float.niu
+++ b/examples/float.niu
@@ -1,0 +1,5 @@
+fn main() -> void {
+  let a: f64 = 12.3;
+  let b: f64 = 91.;
+  let c: f64 = 210.e-3;
+}

--- a/lib/std/f64.niu
+++ b/lib/std/f64.niu
@@ -1,0 +1,18 @@
+import "opes.niu"
+
+impl Add<f64> for f64 {
+  type Output = f64;
+  fn add(a: Self, b: f64) -> f64 $${a + b}$$
+}
+impl Sub<f64> for f64 {
+  type Output = f64;
+  fn sub(a: Self, b: f64) -> f64 $${a - b}$$
+}
+impl Mul<f64> for f64 {
+  type Output = f64;
+  fn mul(a: Self, b: f64) -> f64 $${a * b}$$
+}
+impl Div<f64> for f64 {
+  type Output = f64;
+  fn div(a: Self, b: f64) -> f64 $${a / b}$$
+}

--- a/src/type_id.rs
+++ b/src/type_id.rs
@@ -30,6 +30,7 @@ impl Transpile for TypeId {
         match self.id.into_string().as_str() {
             "i64" => "std::int_fast64_t",
             "u64" => "std::uint_fast64_t",
+            "f64" => "double",
             "bool" => "bool",
             "void" => "void",
             s => s,

--- a/src/unify/traits_info.rs
+++ b/src/unify/traits_info.rs
@@ -42,6 +42,7 @@ impl<'a> TraitsInfo<'a> {
             typeids: vec![
                 (TypeId::from_str("i64"), StructDefinitionInfo::Primitive),
                 (TypeId::from_str("u64"), StructDefinitionInfo::Primitive),
+                (TypeId::from_str("f64"), StructDefinitionInfo::Primitive),
                 (TypeId::from_str("bool"), StructDefinitionInfo::Primitive),
                 (TypeId::from_str("void"), StructDefinitionInfo::Primitive),
                 ].into_iter().collect(),


### PR DESCRIPTION
Close #50 
- `nom::number::complete::recognize_float`を用いてパース(https://docs.rs/nom/7.0.0/nom/number/complete/fn.recognize_float.html)
- `.`を含むかどうかで`u64`と区別することにしている