### PR TITLE
block parser for return if expr

### DIFF
--- a/lib/math/modint.niu
+++ b/lib/math/modint.niu
@@ -24,9 +24,9 @@ struct Modint<M> where M: Mod {
       if exp & 1 == 1 {
         ans = ans * now;
       }
-      else {};
+      else {}
       now = now * now;
-    };
+    }
     ans
   }
   fn inv(self: &Self) -> Self {

--- a/src/expression/for_expr.rs
+++ b/src/expression/for_expr.rs
@@ -59,12 +59,11 @@ impl MutCheck for ForExpr {
 }
 
 pub fn parse_for_expr_paren(s: &str) -> IResult<&str, Expression> {
-    let (s, (_, _, _, _, init, _, _, _, cond, _, _, _, update, _, _, _, _, _, block, _, _)) =
+    let (s, (_, _, _, _, init, _, _, _, cond, _, _, _, update, _, _, _, block)) =
         tuple((tag("for"), multispace0, char('('), multispace0,
             parse_statement, multispace0, char(';'), multispace0,
             parse_expression, multispace0, char(';'), multispace0,
-            alt((parse_substitute_to_statement, parse_expression_to_statement)), multispace0, char(')'), multispace0, char('{'), multispace0,
-            parse_block, multispace0, char('}')))(s)?;
+            alt((parse_substitute_to_statement, parse_expression_to_statement)), multispace0, char(')'), multispace0, parse_block))(s)?;
     Ok((s, Expression::ForExpr(Box::new(ForExpr { init, cond, update, block }))))
 }
 
@@ -74,12 +73,11 @@ fn parse_initial_variable(s: &str) -> IResult<&str, Statement> {
 }
 
 pub fn parse_for_expr_no_parentheses(s: &str) -> IResult<&str, Expression> {
-    let (s, (_, _, init, _, _, _, cond, _, _, _, update, _, _, _, block, _, _)) =
+    let (s, (_, _, init, _, _, _, cond, _, _, _, update, _, block)) =
         tuple((tag("for"), multispace1,
             parse_initial_variable, multispace0, char(';'), multispace0,
             parse_expression, multispace0, char(';'), multispace0,
-            alt((parse_substitute_to_statement, parse_expression_to_statement)), multispace0, char('{'), multispace0,
-            parse_block, multispace0, char('}')))(s)?;
+            alt((parse_substitute_to_statement, parse_expression_to_statement)), multispace0, parse_block))(s)?;
     Ok((s, Expression::ForExpr(Box::new(ForExpr { init, cond, update, block }))))
 }
 

--- a/src/expression/if_expr.rs
+++ b/src/expression/if_expr.rs
@@ -82,11 +82,11 @@ impl MutCheck for IfExpr {
 }
 
 pub fn parse_if_expr(s: &str) -> IResult<&str, Expression> {
-    let (s, (_, _, if_cond, _, _, if_block, _, _, many, _, _, _, el_block, _, _)) = tuple((tag("if"), multispace1, parse_expression, multispace0, char('{'), parse_block, char('}'), multispace0,
-                        many0(tuple((tag("else"), multispace1, tag("if"), multispace1, parse_expression, multispace0, char('{'), parse_block, char('}'), multispace0))),
-                        tag("else"), multispace1, char('{'), parse_block, char('}'), multispace0))(s)?;
+    let (s, (_, _, if_cond, _, if_block, _, many, _, _, el_block, _)) = tuple((tag("if"), multispace1, parse_expression, multispace0, parse_block, multispace0,
+                        many0(tuple((tag("else"), multispace1, tag("if"), multispace1, parse_expression, multispace0, parse_block, multispace0))),
+                        tag("else"), multispace0, parse_block, multispace0))(s)?;
     let ifp = IfPair { cond: if_cond, block: if_block };
-    let elifp = many.into_iter().map(|(_, _, _, _, cond, _, _, block, _, _)| IfPair { cond, block }).collect::<Vec<_>>();
+    let elifp = many.into_iter().map(|(_, _, _, _, cond, _, block, _)| IfPair { cond, block }).collect::<Vec<_>>();
     Ok((s, Expression::IfExpr(Box::new(IfExpr { ifp, elifp, el_block, tag: Tag::new(), }))))
 }
 

--- a/src/func_definition.rs
+++ b/src/func_definition.rs
@@ -343,7 +343,7 @@ pub fn parse_func_definition_info(s: &str) -> IResult<&str, FuncDefinitionInfo> 
 }
 
 fn parse_func_block_block(s: &str) -> IResult<&str, FuncBlock> {
-    let (s, (_, block, _)) = tuple((char('{'), parse_block, char('}')))(s)?;
+    let (s, block) = parse_block(s)?;
     Ok((s, FuncBlock::Block(block)))
 }
 

--- a/src/unary_expr.rs
+++ b/src/unary_expr.rs
@@ -173,7 +173,7 @@ pub fn parse_parentheses(s: &str) -> IResult<&str, UnaryExpr> {
 }
 
 pub fn parse_bracket_block(s: &str) -> IResult<&str, UnaryExpr> {
-    let(s, (_, _, block, _, _)) = tuple((char('{'), multispace0, parse_block, multispace0, char('}')))(s)?;
+    let(s, block) = parse_block(s)?;
     Ok((s, UnaryExpr::Block(block)))
 }
 


### PR DESCRIPTION
#43 これがバグっていました
blockの最後にifが来た時に, return扱いにならないようになっていた